### PR TITLE
fix issue where custom flags based on compound disco definitions were…

### DIFF
--- a/R/custom-chunks.R
+++ b/R/custom-chunks.R
@@ -106,7 +106,7 @@ as_report_template <- function(output, colname) {
   select
   {{{id_field}}} as ##{{{id_type}}}##,
   {{{columnspecs}}}
-  from ({{from}})
+  from ({{{from}}})
   {{#haswhere}}
   where {{{where}}}
   {{/haswhere}}

--- a/R/custom-helper-disco-to-chunk.R
+++ b/R/custom-helper-disco-to-chunk.R
@@ -68,7 +68,9 @@ widget_to_chunk <- function(def, output, isgrouped, fmt,
   res$household <- household
 
   tbl <- listbuilder::get_table(def)
-  if (tbl == "custom")
+  if (is.null(tbl))
+    res$from <- listbuilder::to_sql(def)
+  else if (tbl == "custom")
     res$from <- def$custom
   else if (tbl == "manual")
     res$from <- listbuilder::to_sql(def)
@@ -80,7 +82,12 @@ widget_to_chunk <- function(def, output, isgrouped, fmt,
   res$having <- listbuilder::get_having(def)
   res$output <- output
   res$id_type <- listbuilder::get_id_type(def)
-  res$id_field <- listbuilder::get_id_field(def)
+
+  # atomic definitions have a defined id_field, but compound ones are defined
+  # by id_type
+  if (!is.null(def$operator))
+    res$id_field <- listbuilder::get_id_type(def)
+  else res$id_field <- listbuilder::get_id_field(def)
   res$where <- listbuilder::get_where(def)
   res$summarizer <- summarizer
   res

--- a/tests/testthat/test-custom-flags.R
+++ b/tests/testthat/test-custom-flags.R
@@ -1,0 +1,41 @@
+context("custom flags")
+library(discoveryengine)
+
+test_that("custom_flags work for any disco engine definition", {
+  # atomic, compound, flist, custom
+  wealthy = has_capacity(1)
+  flag1 = has_interest(MUS)
+  flag2 = flag1 %and% majored_in(540)
+  flag3 = parent_of(flag1)
+  flag4 = gave_to_area(HSB)
+  flag5 = flag4 %and% flag2
+  flag6 = parent_of(flag5)
+
+
+  test1 = wealthy %>%
+    custom(flag1 = flag1)
+
+  test2 = wealthy %>% custom(flag1 = flag1, flag2 = flag2)
+  test3 = wealthy %>% custom(flag3 = flag3)
+  test4 = wealthy %>% custom(flag1 = flag1, flag4 = flag4)
+  test5 = wealthy %>% custom(flag5 = flag5)
+  test6 = wealthy %>% custom(flag6 = flag6)
+  test7 = wealthy %>% custom(
+    flag1 = flag1,
+    flag2 = flag2,
+    flag3 = flag3,
+    flag4 = flag4,
+    flag5 = flag5,
+    flag6 = flag6
+  )
+
+  # ideally, we also test the generated SQL from these
+  expect_is(test1, "report")
+  expect_is(test2, "report")
+  expect_is(test3, "report")
+  expect_is(test4, "report")
+  expect_is(test5, "report")
+  expect_is(test6, "report")
+  expect_is(test7, "report")
+})
+


### PR DESCRIPTION
This fixes Will's problem without creating any new ones. But it's clear that `listbuilder` might need to be overhauled at some point to simplify some of this stuff. 